### PR TITLE
Ignored mobs

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
+++ b/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
@@ -70,21 +70,21 @@ public class PelletListener implements Listener {
     protected boolean canCapture(Player p, LivingEntity entity) {
 
         if (!Slimefun.getProtectionManager().hasPermission(p, entity.getLocation(), Interaction.ATTACK_ENTITY)) {
-            //no permission check
+            // no permission check
             return false;
         }
 
         List<String> ignoredMobNames = MobCapturer.getRegistry().getConfig().getStringList("options.ignored-mobs");
         if (ignoredMobNames.contains(entity.getCustomName())) {
-            //filter out ignored mob names
+            // filter out ignored mob names
             return false;
         }
 
         if (MobCapturer.getRegistry().getConfig().getBoolean("options.capture-named-mobs")) {
-            //check if the mob has a name, if not return false
+            // check if the mob has a name, if not return false
             return entity.getCustomName() != null;
         }
-        //passed all fail checks
+        // passed all fail checks
         return true;
     }
 

--- a/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
+++ b/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
@@ -84,7 +84,6 @@ public class PelletListener implements Listener {
             // check if the mob has a name, if not return false
             return entity.getCustomName() != null;
         }
-        // passed all fail checks
         return true;
     }
 

--- a/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
+++ b/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
@@ -1,5 +1,6 @@
 package io.github.thebusybiscuit.mobcapturer.listeners;
 
+import java.util.List;
 import java.util.Optional;
 
 import javax.annotation.Nonnull;
@@ -67,15 +68,24 @@ public class PelletListener implements Listener {
      */
     @ParametersAreNonnullByDefault
     protected boolean canCapture(Player p, LivingEntity entity) {
-        if (Slimefun.getProtectionManager().hasPermission(p, entity.getLocation(), Interaction.ATTACK_ENTITY)) {
-            if (MobCapturer.getRegistry().getConfig().getBoolean("options.capture-named-mobs")) {
-                return true;
-            } else {
-                return entity.getCustomName() == null;
-            }
-        } else {
+
+        if (!Slimefun.getProtectionManager().hasPermission(p, entity.getLocation(), Interaction.ATTACK_ENTITY)) {
+            //no permission check
             return false;
         }
+
+        List<String> ignoredMobNames = MobCapturer.getRegistry().getConfig().getStringList("options.ignored-mobs");
+        if(ignoredMobNames.contains(entity.getCustomName())) {
+            //filter out ignored mob names
+            return false;
+        }
+
+        if(MobCapturer.getRegistry().getConfig().getBoolean("options.capture-named-mobs")) {
+            //check if the mob has a name, if not return false
+            return entity.getCustomName() != null;
+        }
+        //passed all fail checks
+        return true;
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
+++ b/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
@@ -75,12 +75,12 @@ public class PelletListener implements Listener {
         }
 
         List<String> ignoredMobNames = MobCapturer.getRegistry().getConfig().getStringList("options.ignored-mobs");
-        if(ignoredMobNames.contains(entity.getCustomName())) {
+        if (ignoredMobNames.contains(entity.getCustomName())) {
             //filter out ignored mob names
             return false;
         }
 
-        if(MobCapturer.getRegistry().getConfig().getBoolean("options.capture-named-mobs")) {
+        if (MobCapturer.getRegistry().getConfig().getBoolean("options.capture-named-mobs")) {
             //check if the mob has a name, if not return false
             return entity.getCustomName() != null;
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,4 @@
 options:
   auto-update: true
   capture-named-mobs: true
+  ignored-mobs: []


### PR DESCRIPTION
This new ignored-mobs config option accepts a list of strings containing the names of the mobs that should be ignored.
If the name matches with one of the mobs in the list, it will ignore the mob and the capture will not happen.

I also refactored the canCapture method a bit to no longer use else statements making the code a bit more readable and allowing to extend the canCapture method more easily.