### PR TITLE
Ignored mobs (hotfix + color stripping support)

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
+++ b/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
@@ -82,7 +82,7 @@ public class PelletListener implements Listener {
 
         if (MobCapturer.getRegistry().getConfig().getBoolean("options.capture-named-mobs")) {
             // check if the mob has a name, if not return false
-            return entity.getCustomName() != null;
+            return entity.getCustomName() == null;
         }
         return true;
     }

--- a/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
+++ b/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
@@ -76,7 +76,7 @@ public class PelletListener implements Listener {
         }
 
         if (!MobCapturer.getRegistry().getConfig().getBoolean("options.capture-named-mobs") 
-        && entity.getCustomName() != null) { 
+            && entity.getCustomName() != null) { 
         	return false;
         }
 

--- a/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
+++ b/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
@@ -76,20 +76,19 @@ public class PelletListener implements Listener {
             return false;
         }
 
-        List<String> ignoredMobNames = MobCapturer.getRegistry().getConfig().getStringList("options.ignored-mobs");
-        if (ignoredMobNames.size() > 0){
-            String strippedEntityName = ChatColor.stripColor(entity.getCustomName());
-            List<String> strippedMatches = ignoredMobNames.stream()
-                .filter(mobName -> mobName.equalsIgnoreCase(strippedEntityName))
-                .toList();
-            if (strippedMatches.size() > 0){
+        if (!MobCapturer.getRegistry().getConfig().getBoolean("options.capture-named-mobs")) {
+            if (entity.getCustomName() != null){
                 return false;
             }
         }
 
-        if (!MobCapturer.getRegistry().getConfig().getBoolean("options.capture-named-mobs")) {
-            if (entity.getCustomName() != null){
-                return false;
+        List<String> ignoredMobNames = MobCapturer.getRegistry().getConfig().getStringList("options.ignored-mobs");
+        if (ignoredMobNames.size() > 0){
+            String strippedEntityName = ChatColor.stripColor(entity.getCustomName());
+            for(String ignoredMobName: ignoredMobNames){
+                if(ignoredMobName.equalsIgnoreCase(strippedEntityName)){
+                    return false;
+                }
             }
         }
         return true;

--- a/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
+++ b/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
@@ -85,7 +85,7 @@ public class PelletListener implements Listener {
         List<String> ignoredMobNames = MobCapturer.getRegistry().getConfig().getStringList("options.ignored-mobs");
         if (ignoredMobNames.size() > 0){
             String strippedEntityName = ChatColor.stripColor(entity.getCustomName());
-            for(String ignoredMobName: ignoredMobNames){
+            for (String ignoredMobName : ignoredMobNames) {
                 if (ignoredMobName.equalsIgnoreCase(strippedEntityName)) {
                     return false;
                 }

--- a/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
+++ b/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
@@ -76,10 +76,9 @@ public class PelletListener implements Listener {
             return false;
         }
 
-        if (!MobCapturer.getRegistry().getConfig().getBoolean("options.capture-named-mobs")) {
-            if (entity.getCustomName() != null){
-                return false;
-            }
+        if (!MobCapturer.getRegistry().getConfig().getBoolean("options.capture-named-mobs") 
+        && entity.getCustomName() != null) { 
+        	return false;
         }
 
         List<String> ignoredMobNames = MobCapturer.getRegistry().getConfig().getStringList("options.ignored-mobs");

--- a/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
+++ b/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
@@ -2,10 +2,12 @@ package io.github.thebusybiscuit.mobcapturer.listeners;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import org.bukkit.ChatColor;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Snowball;
@@ -75,14 +77,20 @@ public class PelletListener implements Listener {
         }
 
         List<String> ignoredMobNames = MobCapturer.getRegistry().getConfig().getStringList("options.ignored-mobs");
-        if (ignoredMobNames.contains(entity.getCustomName())) {
-            // filter out ignored mob names
-            return false;
+        if (ignoredMobNames.size() > 0){
+            String strippedEntityName = ChatColor.stripColor(entity.getCustomName());
+            List<String> strippedMatches = ignoredMobNames.stream()
+                .filter(mobName -> mobName.equalsIgnoreCase(strippedEntityName))
+                .toList();
+            if (strippedMatches.size() > 0){
+                return false;
+            }
         }
 
-        if (MobCapturer.getRegistry().getConfig().getBoolean("options.capture-named-mobs")) {
-            // check if the mob has a name, if not return false
-            return entity.getCustomName() == null;
+        if (!MobCapturer.getRegistry().getConfig().getBoolean("options.capture-named-mobs")) {
+            if (entity.getCustomName() != null){
+                return false;
+            }
         }
         return true;
     }

--- a/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
+++ b/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
@@ -2,7 +2,6 @@ package io.github.thebusybiscuit.mobcapturer.listeners;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
+++ b/src/main/java/io/github/thebusybiscuit/mobcapturer/listeners/PelletListener.java
@@ -86,7 +86,7 @@ public class PelletListener implements Listener {
         if (ignoredMobNames.size() > 0){
             String strippedEntityName = ChatColor.stripColor(entity.getCustomName());
             for(String ignoredMobName: ignoredMobNames){
-                if(ignoredMobName.equalsIgnoreCase(strippedEntityName)){
+                if (ignoredMobName.equalsIgnoreCase(strippedEntityName)) {
                     return false;
                 }
             }


### PR DESCRIPTION
- Fixed the bug where it would always ignore nameless mobs
- Added color, config.yml no longer requires the color tags in order to detect the mob.

**IMPORTANT**: the ignored-mobs section will override the capture-named-mobs property